### PR TITLE
Add basic Node backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ Welcome to the all-new, premium digital CV and portfolio for Mohamed H Abdelaziz
 4. **Connect chatbot**: In `script.js`, set your backend endpoint for the chatbot.
 5. **Switch language**: Use the toggle button for Arabic/English.
 
+## 🖥️ Local Development
+
+1. Install Node.js (v18 or higher recommended).
+2. Run `npm install` to install Express and other dependencies.
+3. Start the local server with `npm start`.
+4. Open `http://localhost:3000` in your browser.
+
 ---
 
 ## ✨ Credits

--- a/geminiService.js
+++ b/geminiService.js
@@ -1,2 +1,13 @@
-// Gemini 1.5 API integration service
-// (DELETED: No longer used, per user request)
+// Simple placeholder Gemini service used during local development
+// In a real deployment, this would call the Gemini 1.5 API.
+async function generateResponse(messages) {
+  const userMessage = messages.find(m => m.role === 'user');
+  const text = userMessage ? userMessage.content : 'Hello';
+  return {
+    candidates: [
+      { content: { parts: [ { text: `Echo: ${text}` } ] } }
+    ]
+  };
+}
+
+module.exports = { generateResponse };

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "amrikyy-portfolio",
+  "version": "1.0.0",
+  "description": "Digital ID Card Generator and portfolio site",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/routes/chat.js
+++ b/routes/chat.js
@@ -2,6 +2,13 @@ const express = require('express');
 const router = express.Router();
 const geminiService = require('../geminiService');
 
+// Simple in-memory conversation store
+const conversationContext = new Map();
+
+async function setConversationContext(userId, context) {
+    conversationContext.set(userId, context);
+}
+
 router.post('/', async (req, res) => {
     try {
         const userMessage = req.body.prompt;

--- a/script.js
+++ b/script.js
@@ -494,19 +494,23 @@ function initChatbot() {
     // Add user message to chat
     addChatMessage(message, 'user');
     
-    // Simulate bot response (in a real implementation, this would call the backend)
-    setTimeout(() => {
-      // Example responses - in a real implementation, these would come from the backend
-      const responses = [
-        "I'm here to help you create your digital ID card. Would you like to get started?",
-        "The Amrikyy Digital ID is a unique way to showcase your digital identity. Try it out!",
-        "You can customize your digital ID with your own image and preferences.",
-        "Feel free to share your digital ID on social media once you've created it!"
-      ];
-      
-      const randomResponse = responses[Math.floor(Math.random() * responses.length)];
-      addChatMessage(randomResponse, 'bot');
-    }, 1000);
+    // Send message to backend
+    fetch('/api/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt: message })
+    })
+      .then(res => res.json())
+      .then(data => {
+        if (data && data.response) {
+          addChatMessage(data.response, 'bot');
+        } else {
+          addChatMessage('Sorry, something went wrong.', 'bot');
+        }
+      })
+      .catch(() => {
+        addChatMessage('Error contacting server.', 'bot');
+      });
   }
   
   /**

--- a/server.js
+++ b/server.js
@@ -1,0 +1,19 @@
+const express = require('express');
+const path = require('path');
+
+const chatRouter = require('./routes/chat');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.use(express.json());
+
+// Serve static files (HTML, CSS, JS, images)
+app.use(express.static(__dirname));
+
+// API routes
+app.use('/api/chat', chatRouter);
+
+app.listen(PORT, () => {
+  console.log(`Server running on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add package.json for Node dependencies
- implement a simple Express server
- add placeholder Gemini service
- wire up conversation route and update chatbot JS
- document local development steps

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `node server.js` *(fails: cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6846441c04f88330b524a74b516926e1