### PR TITLE
Add rating widget with localStorage

### DIFF
--- a/index.html
+++ b/index.html
@@ -274,6 +274,20 @@
             <i class="fas fa-redo-alt"></i> <span data-translate="resetBtn">إنشاء بطاقة جديدة</span>
           </button>
         </div>
+
+        <!-- Rating Widget -->
+        <div class="rating-widget" data-tool-id="digital-id">
+          <div class="rating-stars">
+            <i class="fa-regular fa-star star" data-value="1"></i>
+            <i class="fa-regular fa-star star" data-value="2"></i>
+            <i class="fa-regular fa-star star" data-value="3"></i>
+            <i class="fa-regular fa-star star" data-value="4"></i>
+            <i class="fa-regular fa-star star" data-value="5"></i>
+          </div>
+          <textarea class="rating-comment" placeholder="Leave a comment (optional)"></textarea>
+          <button class="rating-submit">Submit</button>
+          <div class="rating-average">Average rating: <span>0</span></div>
+        </div>
       </div>
     </section>
 

--- a/script.js
+++ b/script.js
@@ -30,6 +30,9 @@ document.addEventListener('DOMContentLoaded', () => {
   
   // Initialize share functionality
   initShareFunctionality();
+
+  // Initialize rating widgets
+  initRatingWidgets();
   
   // Hero section CTA buttons
   const aiToolHeroBtn = document.getElementById('aiToolHeroBtn');
@@ -895,8 +898,81 @@ function showLoadingOverlay(message = 'Loading...') {
  */
 function hideLoadingOverlay() {
   const loadingOverlay = document.getElementById('loadingOverlay');
-  
+
   if (loadingOverlay) {
     loadingOverlay.classList.add('hidden');
   }
+}
+
+/**
+ * Initialize rating widgets and handle persistence
+ */
+function initRatingWidgets() {
+  const widgets = document.querySelectorAll('.rating-widget');
+  if (!widgets.length) return;
+
+  let ratingsStore = {};
+  try {
+    ratingsStore = JSON.parse(localStorage.getItem('toolRatings')) || {};
+  } catch (e) {
+    ratingsStore = {};
+  }
+
+  widgets.forEach(widget => {
+    const toolId = widget.getAttribute('data-tool-id');
+    const stars = widget.querySelectorAll('.star');
+    const commentInput = widget.querySelector('.rating-comment');
+    const submitBtn = widget.querySelector('.rating-submit');
+    const averageDisplay = widget.querySelector('.rating-average span');
+    let selected = 0;
+
+    updateAverage();
+
+    stars.forEach(star => {
+      const value = parseInt(star.dataset.value, 10);
+      star.addEventListener('mouseenter', () => highlight(value));
+      star.addEventListener('mouseleave', () => highlight(selected));
+      star.addEventListener('click', () => {
+        selected = value;
+        highlight(selected);
+      });
+    });
+
+    if (submitBtn) {
+      submitBtn.addEventListener('click', () => {
+        if (!selected) return alert('Please select a rating first');
+        const comment = commentInput ? commentInput.value.trim() : '';
+        if (!ratingsStore[toolId]) ratingsStore[toolId] = { ratings: [] };
+        ratingsStore[toolId].ratings.push({ stars: selected, comment });
+        localStorage.setItem('toolRatings', JSON.stringify(ratingsStore));
+        if (commentInput) commentInput.value = '';
+        selected = 0;
+        highlight(selected);
+        updateAverage();
+      });
+    }
+
+    function highlight(rating) {
+      stars.forEach(s => {
+        const val = parseInt(s.dataset.value, 10);
+        if (val <= rating) {
+          s.classList.add('fa-solid', 'active');
+          s.classList.remove('fa-regular');
+        } else {
+          s.classList.remove('fa-solid', 'active');
+          s.classList.add('fa-regular');
+        }
+      });
+    }
+
+    function updateAverage() {
+      if (ratingsStore[toolId] && ratingsStore[toolId].ratings.length) {
+        const arr = ratingsStore[toolId].ratings;
+        const avg = arr.reduce((a, r) => a + r.stars, 0) / arr.length;
+        averageDisplay.textContent = avg.toFixed(1);
+      } else {
+        averageDisplay.textContent = '0';
+      }
+    }
+  });
 }

--- a/style.css
+++ b/style.css
@@ -1721,3 +1721,55 @@ html[dir="rtl"] .next-btn:hover {
   white-space: nowrap;
   border-width: 0;
 }
+
+/* Rating Widget */
+.rating-widget {
+  margin-top: 2rem;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.rating-stars .star {
+  font-size: 1.5rem;
+  color: #ccc;
+  cursor: pointer;
+  margin: 0 0.25rem;
+  transition: color 0.2s;
+}
+
+.rating-stars .star.active {
+  color: #FFD700;
+}
+
+.rating-comment {
+  width: 100%;
+  max-width: 300px;
+  min-height: 60px;
+  padding: 0.5rem;
+  border-radius: var(--border-radius-md);
+  border: none;
+  resize: vertical;
+}
+
+.rating-submit {
+  padding: 0.4rem 1rem;
+  border-radius: var(--border-radius-sm);
+  cursor: pointer;
+  font-family: var(--font-orbitron);
+  background-color: var(--neon-blue);
+  color: #fff;
+  border: none;
+  transition: background-color 0.2s;
+}
+
+.rating-submit:hover {
+  background-color: var(--neon-green);
+}
+
+.rating-average {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}


### PR DESCRIPTION
## Summary
- add rating widget markup to `index.html`
- style the new rating component in `style.css`
- store ratings in localStorage via `initRatingWidgets` in `script.js`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684a5e33c20083308199fad2a2f084eb