### PR TITLE
Add hover glow to ID card

### DIFF
--- a/style.css
+++ b/style.css
@@ -1424,6 +1424,12 @@ html[dir="rtl"] .input-container select {
   color: var(--text-primary);
   box-shadow: var(--shadow-md);
   position: relative;
+  transition: box-shadow var(--transition-speed) var(--transition-easing);
+}
+
+/* Hover glow for generated cards */
+.digital-id-card .card:hover {
+  box-shadow: var(--shadow-md), var(--shadow-neon-blue), var(--shadow-neon-green);
 }
 
 .card-header,


### PR DESCRIPTION
## Summary
- subtly highlight `.digital-id-card .card` on hover by adding neon shadows
- ensure hover effect transitions smoothly

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684a5e2e11088330b55d455c31d8c761