### PR TITLE
Add request size validation

### DIFF
--- a/routes/chat.js
+++ b/routes/chat.js
@@ -18,6 +18,11 @@ router.post('/', async (req, res) => {
             return res.status(400).json({ error: 'No prompt provided' });
         }
 
+        const MAX_PROMPT_BYTES = 1024; // 1KB
+        if (Buffer.byteLength(userMessage, 'utf8') > MAX_PROMPT_BYTES) {
+            return res.status(413).json({ error: 'Prompt too large' });
+        }
+
         // --- System prompt/persona ---
         const systemPrompt = `أنت "Amrikyy"، مساعد ذكي متخصص في التقنية والعملات الرقمية وتجربة المستخدم. أجب دائماً بأسلوب ودود، حديث، واحترافي، ووضح الإجابات بلغة سهلة مع لمسة من الحماس التقني. إذا كان السؤال متعلقاً بالسيرة الذاتية أو المهارات أو المشاريع، قدّم إجابة مختصرة وواضحة. إذا كان السؤال عن التقنية أو الذكاء الاصطناعي أو العملات الرقمية، أضف لمسة من الشرح المبسط والأمثلة العملية.`;
 

--- a/server.js
+++ b/server.js
@@ -24,6 +24,12 @@ app.get('/api/qr', async (req, res) => {
     if (!data) {
       return res.status(400).json({ error: 'Missing data parameter' });
     }
+
+    const MAX_QR_BYTES = 2 * 1024; // 2KB
+    if (Buffer.byteLength(data, 'utf8') > MAX_QR_BYTES) {
+      return res.status(413).json({ error: 'Data parameter too large' });
+    }
+
     const qrDataUrl = await QRCode.toDataURL(data);
     res.json({ dataUrl: qrDataUrl });
   } catch (err) {

--- a/tests/api.qr.test.js
+++ b/tests/api.qr.test.js
@@ -12,4 +12,10 @@ describe('GET /api/qr', () => {
     expect(res.statusCode).toBe(200);
     expect(res.body).toHaveProperty('dataUrl');
   });
+
+  it('returns 413 when data parameter exceeds limit', async () => {
+    const largeData = 'a'.repeat(2049);
+    const res = await request(app).get('/api/qr').query({ data: largeData });
+    expect(res.statusCode).toBe(413);
+  });
 });

--- a/tests/chat.test.js
+++ b/tests/chat.test.js
@@ -23,6 +23,13 @@ describe('POST /api/chat', () => {
     expect(res.body.response).toBe('hi');
   });
 
+  it('rejects prompts over 1KB', async () => {
+    const longPrompt = 'a'.repeat(1025);
+    const res = await request(app).post('/api/chat').send({ prompt: longPrompt });
+    expect(res.statusCode).toBe(413);
+    expect(gemini.generateResponse).not.toHaveBeenCalled();
+  });
+
   it('handles service errors gracefully', async () => {
     gemini.generateResponse.mockRejectedValue(new Error('fail'));
     const res = await request(app).post('/api/chat').send({ prompt: 'hi' });


### PR DESCRIPTION
## Summary
- prevent excessively large data when generating QR codes
- reject chat prompts over 1KB
- test QR endpoint for oversized data
- test chat endpoint for oversized prompts

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685270d7c794833087de6ea5deb9bc59